### PR TITLE
Made walkingkooka:j2cl-maven-plugin compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GWT Editor
 
-![GWT3/J2CL compatible](https://img.shields.io/badge/GWT3/J2CL-compatible-brightgreen.svg)  [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Chat on Gitter](https://badges.gitter.im/hal/elemento.svg)](https://gitter.im/gwtproject/gwt-modules) ![CI](https://github.com/gwtproject/gwt-editor/workflows/CI/badge.svg)
+![GWT3/J2CL compatible](https://img.shields.io/badge/GWT3/J2CL-compatible-brightgreen.svg)  [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Chat on Gitter](https://badges.gitter.im/hal/elemento.svg)](https://gitter.im/gwtproject/gwt-modules) ![CI](https://github.com/mP1/j2cl-gwt-editor/workflows/CI/badge.svg)
 
 A future-proof port of the `com.google.gwt.editor.Editor` GWT module, with no dependency on `gwt-user` (besides the Java Runtime Emulation), to prepare for GWT 3 / J2Cl.
 
@@ -13,7 +13,7 @@ A future-proof port of the `com.google.gwt.editor.Editor` GWT module, with no de
    ```xml
    <dependency>
      <groupId>org.gwtproject.editor</groupId>
-     <artifactId>gwt-editor</artifactId>
+     <artifactId>j2cl-gwt-editor</artifactId>
      <version>HEAD-SNAPSHOT</version>
    </dependency>
    ```
@@ -23,7 +23,7 @@ A future-proof port of the `com.google.gwt.editor.Editor` GWT module, with no de
     ```xml
     <dependency>
       <groupId>org.gwtproject.editor</groupId>
-      <artifactId>gwt-editor-processor</artifactId>
+      <artifactId>j2cl-gwt-editor-processor</artifactId>
       <version>HEAD-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
@@ -32,7 +32,7 @@ A future-proof port of the `com.google.gwt.editor.Editor` GWT module, with no de
    For Gradle:
 
    ```gradle
-   implementation("org.gwtproject.editor:gwt-editor:HEAD-SNAPSHOT")
+   implementation("org.gwtproject.editor:j2cl-gwt-editor:HEAD-SNAPSHOT")
    ```
 
     and the processor:
@@ -41,7 +41,7 @@ A future-proof port of the `com.google.gwt.editor.Editor` GWT module, with no de
    ToDo ... 
     <dependency>
       <groupId>org.gwtproject.editor</groupId>
-      <artifactId>gwt-editor-processor</artifactId>
+      <artifactId>j2cl-gwt-editor-processor</artifactId>
       <version>HEAD-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>

--- a/gwt-editor-gwt2-tests/pom.xml
+++ b/gwt-editor-gwt2-tests/pom.xml
@@ -4,13 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.gwtproject.editor</groupId>
-        <artifactId>gwt-editor-parent</artifactId>
-        <version>dev</version>
+        <groupId>walkingkooka</groupId>
+        <artifactId>j2cl-gwt-editor-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>gwt-editor-gwt2-tests</artifactId>
-    <version>${revision}</version>
-    <packaging>gwt-lib</packaging>
+    <artifactId>j2cl-gwt-editor-gwt2-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
 
     <name>GWT Editor GWT 2 Tests</name>
     <description>Test cases for the GWT 2 tests</description>
@@ -37,15 +36,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.gwtproject.editor</groupId>
-            <artifactId>gwt-editor</artifactId>
-            <version>${revision}</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-gwt-editor</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.gwtproject.editor</groupId>
-            <artifactId>gwt-editor-processor</artifactId>
-            <version>${revision}</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-gwt-editor-processor</artifactId>
+            <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/gwt-editor-j2cl-tests/pom.xml
+++ b/gwt-editor-j2cl-tests/pom.xml
@@ -4,16 +4,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.gwtproject.editor</groupId>
-    <artifactId>gwt-editor-parent</artifactId>
-    <version>dev</version>
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-gwt-editor-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>gwt-editor-j2cl-tests</artifactId>
-  <version>${revision}</version>
+  <artifactId>j2cl-gwt-editor-j2cl-tests</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
   <name>GWT Editor J2CL Tests</name>
   <description>Test cases for the J2Cl tests</description>
-  <url>https://github.com/gwtproject/gwt-editor</url>
+  <url>https://github.com/mP1/j2cl-gwt-editor</url>
 
   <properties>
     <maven.j2cl.plugin>0.16-SNAPSHOT</maven.j2cl.plugin>
@@ -25,42 +25,85 @@
   </properties>
 
   <dependencies>
-    <!-- test dependencies -->
     <dependency>
-      <groupId>com.vertispan.j2cl</groupId>
-      <artifactId>junit-annotations</artifactId>
-      <version>${j2cl.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vertispan.j2cl</groupId>
-      <artifactId>gwttestcase-emul</artifactId>
-      <version>${j2cl.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.vertispan.j2cl</groupId>
-      <artifactId>junit-emul</artifactId>
-      <version>${j2cl.version}</version>
-      <scope>test</scope>
+      <groupId>walkingkooka</groupId>
+      <artifactId>j2cl-uber-test</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
-      <groupId>org.gwtproject.editor</groupId>
-      <artifactId>gwt-editor</artifactId>
-      <version>${revision}</version>
-<!--      <scope>test</scope>-->
+      <groupId>walkingkooka</groupId>
+      <artifactId>j2cl-gwt-editor</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>org.gwtproject.editor</groupId>
-      <artifactId>gwt-editor-processor</artifactId>
-      <version>${revision}</version>
+      <groupId>walkingkooka</groupId>
+      <artifactId>j2cl-gwt-editor-processor</artifactId>
+      <version>1.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>walkingkooka</groupId>
+        <artifactId>j2cl-maven-plugin</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>walkingkooka-spreadsheet-it-junit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <browser-log-level>ALL</browser-log-level>
+              <browsers>
+                <param>CHROME</param>
+              </browsers>
+              <classpath-scope>test</classpath-scope>
+              <compilation-level>SIMPLE</compilation-level>
+              <defines>
+                <gwt.cspCompatModeEnabled>true</gwt.cspCompatModeEnabled>
+                <gwt.enableDebugId>true</gwt.enableDebugId>
+                <gwt.strictCspTestingEnabled>true</gwt.strictCspTestingEnabled>
+                <jre.checkedMode>DISABLED</jre.checkedMode>
+                <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
+                <jsinterop.checks>DISABLED</jsinterop.checks>
+              </defines>
+              <externs/>
+              <formatting>
+                <param>PRETTY_PRINT</param>
+              </formatting>
+              <java-compiler-arguments/>
+              <language-out>ECMASCRIPT_2016</language-out>
+              <thread-pool-size>0</thread-pool-size>
+
+              <classpath-required/>
+              <ignored-dependencies>
+                <param>walkingkooka:j2cl-gwt-editor-processor:*</param>
+              </ignored-dependencies>
+              <javascript-source-required/>
+
+              <skip>false</skip>
+              <tests>
+                <param>org.gwtproject.editor.client.DirtyEditorTest</param>
+                <!--
+[ERROR] Failed to execute goal walkingkooka:j2cl-maven-plugin:1.0-SNAPSHOT:test (walkingkooka-spreadsheet-it-junit-test) on project j2cl-gwt-editor-j2cl-tests: Failed to build project, check logs above: java.nio.file.NoSuchFileException: /Users/miroslav/repos-github/j2cl-gwt-editor/gwt-editor-j2cl-tests/target/walkingkooka-j2cl-maven-plugin-cache/walkingkooka--j2cl-gwt-editor-j2cl-tests--jar--1.0-SNAPSHOT-1d370bd0166dfa4c514a3288284dc0c8c464f4af/1-javac-compile/output/org/gwtproject/editor/client/EditorErrorTest.testsuite -> [Help 1]
+org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal walkingkooka:j2cl-maven-plugin:1.0-SNAPSHOT:test (walkingkooka-spreadsheet-it-junit-test) on project j2cl-gwt-editor-j2cl-tests: Failed to build project, check logs above
+                <param>org.gwtproject.editor.client.EditorErrorTest</param>
+                -->
+                <param>org.gwtproject.editor.client.SimpleBeanEditorTest</param>
+                <param>org.gwtproject.editor.client.impl.DelegateMapTest</param>
+                <param>org.gwtproject.editor.client.adapters.ListEditorWrapperTest</param>
+              </tests>
+              <test-timeout>20</test-timeout>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>com.vertispan.j2cl</groupId>
         <artifactId>j2cl-maven-plugin</artifactId>

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -4,16 +4,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.gwtproject.editor</groupId>
-        <artifactId>gwt-editor-parent</artifactId>
-        <version>dev</version>
+        <groupId>walkingkooka</groupId>
+        <artifactId>j2cl-gwt-editor-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>gwt-editor-processor</artifactId>
-    <version>${revision}</version>
+    <artifactId>j2cl-gwt-editor-processor</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GWT Editor Processor</name>
-    <url>https://github.com/gwtproject/gwt-editor</url>
+    <url>https://github.com/mP1/j2cl-gwt-editor</url>
 
     <organization>
         <name>The GWT Project Authors</name>
@@ -36,9 +36,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/gwtproject/gwt-editor.git</connection>
-        <developerConnection>scm:git:ssh://github.com/gwtproject/gwt-editor.git</developerConnection>
-        <url>https://github.com/gwtproject/gwt-editor/tree/master</url>
+        <connection>scm:git:git://github.com/mP1/j2cl-gwt-editor.git</connection>
+        <developerConnection>scm:git:ssh://github.com/mP1/j2cl-gwt-editor.git</developerConnection>
+        <url>https://github.com/mP1/j2cl-gwt-editor/tree/master</url>
     </scm>
 
     <inceptionYear>2018</inceptionYear>
@@ -64,15 +64,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.gwtproject.editor</groupId>
-            <artifactId>gwt-editor</artifactId>
-            <version>${project.version}</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-gwt-editor</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>1.0.0.GA</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-javax-validation</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>
@@ -210,11 +210,11 @@
                         <configuration>
                             <artifactSet>
                                 <excludes>
-                                    <exclude>org.gwtproject.editor:gwt-editor</exclude>
+                                    <exclude>walkingkooka:j2cl-gwt-editor</exclude>
                                     <exclude>org.gwtproject.event:gwt-event</exclude>
                                     <exclude>com.google.auto.service:*</exclude>
                                     <exclude>javax.annotation:javax.annotation-api</exclude>
-                                    <exclude>javax.validation:validation-api</exclude>
+                                    <exclude>walkingkooka:j2cl-javax.validation</exclude>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
                                     <exclude>com.google.j2objc:j2objc-annotations</exclude>
                                     <exclude>com.google.errorprone:error_prone_annotations</exclude>

--- a/gwt-editor/pom.xml
+++ b/gwt-editor/pom.xml
@@ -6,17 +6,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.gwtproject.editor</groupId>
-    <artifactId>gwt-editor-parent</artifactId>
-    <version>dev</version>
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-gwt-editor-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>gwt-editor</artifactId>
-  <version>${revision}</version>
-  <packaging>gwt-lib</packaging>
+  <artifactId>j2cl-gwt-editor</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
   <name>GWT Editor</name>
   <description>A j2cl ready implementation of the GWT Editor Module ready to use with GWT 2 and J2CL / GWT 3.</description>
-  <url>https://github.com/gwtproject/gwt-editor</url>
+  <url>https://github.com/mP1/j2cl-gwt-editor</url>
 
   <organization>
     <name>The GWT Project Authors</name>
@@ -39,9 +38,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/gwtproject/gwt-editor.git</connection>
-    <developerConnection>scm:git:ssh://github.com/gwtproject/gwt-editor.git</developerConnection>
-    <url>https://github.com/gwtproject/gwt-editor/tree/master</url>
+    <connection>scm:git:git://github.com/mP1/j2cl-gwt-editor.git</connection>
+    <developerConnection>scm:git:ssh://github.com/mP1/j2cl-gwt-editor.git</developerConnection>
+    <url>https://github.com/mP1/j2cl-gwt-editor/tree/master</url>
   </scm>
 
   <inceptionYear>2018</inceptionYear>
@@ -58,17 +57,10 @@
       <artifactId>gwt-event</artifactId>
       <version>${gwt-event.version}</version>
     </dependency>
-
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.0.0.GA</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.0.0.GA</version>
-      <classifier>sources</classifier>
+      <groupId>walkingkooka</groupId>
+      <artifactId>j2cl-javax-validation</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 
@@ -144,4 +136,12 @@
       </build>
     </profile>
   </profiles>
+
+  <distributionManagement>
+    <repository>
+      <id>github-mp1-appengine-repo</id>
+      <name>github.com/mP1 repository</name>
+      <url>https://maven-repo-254709.appspot.com</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,16 +3,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.gwtproject.editor</groupId>
-    <artifactId>gwt-editor-parent</artifactId>
-
-    <version>dev</version>
+    <groupId>walkingkooka</groupId>
+    <artifactId>j2cl-gwt-editor-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
     <name>GWT Editor Parent</name>
     <description>Parent POM containing the gwt-event module, gwt-event-processor module and the test modules (gwt2-tests and j2cl-tests)</description>
-    <url>https://github.com/gwtproject/gwt-editor</url>
+    <url>https://github.com/mP1/j2cl-gwt-editor</url>
 
     <organization>
         <name>The GWT Project Authors</name>
@@ -35,9 +34,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/gwtproject/gwt-editors.git</connection>
-        <developerConnection>scm:git:ssh://github.com/gwtproject/gwt-editors.git</developerConnection>
-        <url>https://github.com/gwtproject/gwt-editors/tree/master</url>
+        <connection>scm:git:git://github.com/mP1/j2cl-gwt-editors.git</connection>
+        <developerConnection>scm:git:ssh://github.com/mP1/j2cl-gwt-editors.git</developerConnection>
+        <url>https://github.com/mP1/j2cl-gwt-editors/tree/master</url>
     </scm>
 
     <inceptionYear>2018</inceptionYear>
@@ -45,7 +44,6 @@
     <modules>
         <module>gwt-editor</module>
         <module>gwt-editor-processor</module>
-        <module>gwt-editor-gwt2-tests</module>
         <module>gwt-editor-j2cl-tests</module>
     </modules>
 
@@ -172,26 +170,22 @@
         <dependencies>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>gwt-editor</artifactId>
-                <version>${revision}</version>
+                <artifactId>j2cl-gwt-editor</artifactId>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>gwt-editor-processor</artifactId>
-                <version>${revision}</version>
+                <artifactId>j2cl-gwt-editor-processor</artifactId>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
-
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github-mp1-appengine-repo</id>
+            <name>github.com/mP1 repository</name>
+            <url>https://maven-repo-254709.appspot.com</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
- replaced javax.validation.* with walkingkooka:j2cl-javax-validation
- Assigned new groupIds & artifactIds
- Disabled gwt tests
- No code changes, only changes are to POM.