### PR TITLE
Made walkingkooka:j2cl-maven-plugin compatible 2/2

### DIFF
--- a/gwt-editor-j2cl-tests/pom.xml
+++ b/gwt-editor-j2cl-tests/pom.xml
@@ -90,7 +90,7 @@
               <tests>
                 <param>org.gwtproject.editor.client.DirtyEditorTest</param>
                 <!--
-[ERROR] Failed to execute goal walkingkooka:j2cl-maven-plugin:1.0-SNAPSHOT:test (walkingkooka-spreadsheet-it-junit-test) on project j2cl-gwt-editor-j2cl-tests: Failed to build project, check logs above: java.nio.file.NoSuchFileException: /Users/miroslav/repos-github/j2cl-gwt-editor/gwt-editor-j2cl-tests/target/walkingkooka-j2cl-maven-plugin-cache/walkingkooka--j2cl-gwt-editor-j2cl-tests--jar--1.0-SNAPSHOT-1d370bd0166dfa4c514a3288284dc0c8c464f4af/1-javac-compile/output/org/gwtproject/editor/client/EditorErrorTest.testsuite -> [Help 1]
+[ERROR] Failed to execute goal walkingkooka:j2cl-maven-plugin:1.0-SNAPSHOT:test (walkingkooka-spreadsheet-it-junit-test) on project j2cl-gwt-editor-j2cl-tests: Failed to build project, check logs above: java.nio.file.NoSuchFileException: /Users/miroslav/repos-github/j2cl-gwt-editor/gwt-editor-j2cl-tests/target/walkingkooka-j2cl-maven-plugin-cache/walkingkooka-\-j2cl-gwt-editor-j2cl-tests-\-jar-\-1.0-SNAPSHOT-1d370bd0166dfa4c514a3288284dc0c8c464f4af/1-javac-compile/output/org/gwtproject/editor/client/EditorErrorTest.testsuite -> [Help 1]
 org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal walkingkooka:j2cl-maven-plugin:1.0-SNAPSHOT:test (walkingkooka-spreadsheet-it-junit-test) on project j2cl-gwt-editor-j2cl-tests: Failed to build project, check logs above
                 <param>org.gwtproject.editor.client.EditorErrorTest</param>
                 -->

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -323,5 +323,13 @@
             </build>
         </profile>
     </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>github-mp1-appengine-repo</id>
+            <name>github.com/mP1 repository</name>
+            <url>https://maven-repo-254709.appspot.com</url>
+        </repository>
+    </distributionManagement>
 </project>
 


### PR DESCRIPTION
- replaced javax.validation.* with walkingkooka:j2cl-javax-validation
- Assigned new groupIds & artifactIds
- Disabled gwt tests
- No code changes, only changes are to POM.